### PR TITLE
Removed nocopy label from QMUL json file

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -194,7 +194,7 @@ if __name__ == '__main__':
 
     if 'QMUL' in todos:
         print("Augmenting QMUL (Without \" - Copy\")... ")
-        Xtr, ytr, ntr, Xte, yte, nte, le = load_tosato_clf(datadir, 'QMULPoseHeads-nocopy.json')
+        Xtr, ytr, ntr, Xte, yte, nte, le = load_tosato_clf(datadir, 'QMULPoseHeads.json')
         Xtr, ytr, ntr = flipall_classes(Xtr, ytr, ntr, le, flips=[
             ('front', 'front'),
             ('back', 'back'),


### PR DESCRIPTION
prepare_data.py contains 'nocopy' part in the json filename. But there is no such file in the data folder. We should change prepare_data.py or the name of the json file.
